### PR TITLE
Adding service version logging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,5 +3,8 @@ use fastly::{Error, Request, Response};
 
 #[fastly::main]
 fn main(_req: Request) -> Result<Response, Error> {
+    // Log service version
+    println!("FASTLY_SERVICE_VERSION: {}", std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new()));
+    
     Ok(Response::from_status(StatusCode::OK))
 }


### PR DESCRIPTION
Prints service version to console after running `fastly log-tail`. ([JIRA ticket](https://fastly.atlassian.net/browse/DEVLIB-856?atlOrigin=eyJpIjoiMDY0MmI0YThjZDVhNGE5NjljZjBiZGNjNTkzOWY2NDMiLCJwIjoiaiJ9))