### PR TITLE
2025 Rust starter kit upgrades

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
+
+[term]
+color = "always"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,53 +1,14 @@
-on: pull_request
 name: Test
+
+on:
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'rust-toolchain.toml'
+      - '.cargo/config.toml'
+      - '.github/workflows/test.yml'
+      - 'src/**'
+
 jobs:
   test:
-    strategy:
-      matrix:
-        rust-toolchain: [1.83.0]
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-    environment: test
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.83.0
-    - name: Add wasm32-wasi Rust target
-      run: rustup target add wasm32-wasi --toolchain ${{ matrix.rust-toolchain }}
-    - name: Cache cargo registry
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo index
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo build
-      uses: actions/cache@v3
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install fmt
-      run: rustup component add rustfmt
-      shell: bash
-    - name: Install clippy
-      run: rustup component add clippy
-      shell: bash
-    - name: Install audit
-      run: cargo install cargo-audit
-      shell: bash
-    - name: Check binaries and format
-      run: RUSTFLAGS="--deny warnings" cargo check --bins --target wasm32-wasi && cargo fmt -- --check
-      shell: bash
-    - name: clippy
-      run: cargo clippy
-      shell: bash
-    - name: audit
-      run: cargo audit
-      shell: bash
-    - name: build
-      run: cargo build
-      shell: bash
+    uses: fastly/devex-reusable-workflows/.github/workflows/compute-starter-kit-rust-v1.yml@main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "fastly-compute-project"
 version = "0.1.0"
+authors = []
 edition = "2021"
-# Remove this line if you want to be able to publish this crate as open source on crates.io.
+# Remove this line if you want to be able to publish this crate on crates.io.
 # Otherwise, `publish = false` prevents an accidental `cargo publish` from revealing private source.
 publish = false
 
 [profile.release]
 debug = 1
+codegen-units = 1
+lto = "fat"
 
 [dependencies]
 fastly = "0.11.0"

--- a/fastly.toml
+++ b/fastly.toml
@@ -1,8 +1,11 @@
-authors = ["<oss@fastly.com>"]
-description = "An empty starter kit project template."
+# This file describes a Fastly Compute package. To learn more visit:
+# https://www.fastly.com/documentation/reference/compute/fastly-toml/
+
+name = "Empty starter for Rust"
+description = "Starter kit that provides an empty service."
+authors = ["<devrel@fastly.com>"]
 language = "rust"
 manifest_version = 3
-name = "Empty starter for Rust"
 
 [scripts]
-  build = "cargo build --bin fastly-compute-project --release --target wasm32-wasi --color always"
+  build = "cargo build --profile release"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
-channel = "1.83.0"
-targets = [ "wasm32-wasi" ]
+channel = "stable"
+targets = [ "wasm32-wasip1" ]
+profile = "default"


### PR DESCRIPTION
Starter kit content changes:

* Changed 'wasm32-wasi' target to 'wasm32-wasip1' (requires Rust 1.78 or later and Fastly CLI 11.0 or later)

* Changed rust-toolchain.toml to install 'stable' toolchain instead of '1.83.0'

* Moved term.color=always from scripts.build in fastly.toml to .cargo/config.toml

* Updated Rust edition from 2018 to 2021

* Changed Rust 'release' profile to use LTO

* Removed unnecessary parameters from scripts.build in fastly.toml

Other changes:

* Switched to using a reusable workflow for CI